### PR TITLE
Github requires a user agent header

### DIFF
--- a/bin/ghcopy-authorize
+++ b/bin/ghcopy-authorize
@@ -58,7 +58,10 @@ prompt.get([
       json: { "scopes": ["gist"], 
               "note": "Created by http://github.com/dscape/ghcopy",
               "note_url": "http://github.com/dscape/ghcopy"
-            }
+            },
+      headers: {
+          'User-Agent': 'nodejs ghcopy module'
+      }
     };
 
   //


### PR DESCRIPTION
```
ghcopy@0.1.0 /usr/local/lib/node_modules/ghcopy
├── opener@1.3.0
├── request@2.12.0
├── optimist@0.3.7 (wordwrap@0.0.2)
└── prompt@0.2.9 (revalidator@0.1.5, pkginfo@0.3.0, read@1.0.4, utile@0.1.7, winston@0.6.2)
lloyd-surevine-laptop:buddycloud-server-java lloyd$ ghcopy-authorize 
prompt: username:  lloydwatkin
prompt: password:  
Auth failed, returned status code 403
{ message: 'Missing or invalid User Agent string. See http://developer.github.com/v3/#user-agent-required' }
lloyd-surevine-laptop:buddycloud-server-java lloyd$
```
