### PR TITLE
Removed caos link in README per #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ everyone is welcome to contribute. patches, bug-fixes, reporters, new features.
 * home: <http://github.com/dscape/ghcopy>
 * bugs: <http://github.com/dscape/ghcopy/issues>
 
-`(oO)--',-` in [caos]
-
 <a name="license"/>
 # license
 


### PR DESCRIPTION
Couldn't find a working caos link, so removed it from readme.
